### PR TITLE
Clarify validate-clusters existing config handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ Your system is ready for disaster recovery!
 
 Please see [Documentation](#documentation) to learn more.
 
+## Agentic usage
+
+*ramenctl* is agentic-ready out of the box. Running `ramenctl init`
+installs AI skills that teach your coding assistant how to configure,
+validate, gather diagnostics, and test disaster recovery flows.
+
+```console
+$ ramenctl init -a cursor
+```
+
+See [AI Skills](docs/skills.md) for details.
+
 ## Documentation
 
 Visit the docs below to learn about *ramenctl* commands:
@@ -94,6 +106,7 @@ Visit the docs below to learn about *ramenctl* commands:
 
 Check the guides below to learn more:
 
+- [Using ramenctl with AI agents](docs/skills.md)
 - [Testing disaster recovery with ramenctl](docs/testing.md)
 
 ## Contributing

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -4,33 +4,56 @@
 package commands
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/ramendr/ramenctl/pkg/config"
 	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/ramendr/ramenctl/pkg/skills"
 )
 
-var envFile string
+var (
+	envFile   string
+	agentName string
+)
 
 var InitCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Create configuration file for your clusters",
+	Short: "Create configuration file and install AI skills",
+	// Validate flags early so cobra shows usage on invalid input.
+	PreRunE: func(c *cobra.Command, args []string) error {
+		return skills.ValidateAgent(agentName)
+	},
 	Run: func(c *cobra.Command, args []string) {
-		if err := config.CreateSampleConfig(
-			configFile,
-			RootCmd.DisplayName(),
-			envFile,
-		); err != nil {
-			_ = console.Failed(err)
+		if err := runInit(); err != nil {
 			os.Exit(1)
 		}
-		console.Completed("Created config file %q - please modify for your clusters", configFile)
 	},
 }
 
 func init() {
-	// Register the --envfile flag
 	InitCmd.Flags().StringVar(&envFile, "envfile", "", "ramen testing environment file")
+	InitCmd.Flags().StringVarP(&agentName, "agent", "a", skills.AgentGeneric,
+		fmt.Sprintf("AI agent to install skills for (%s)", strings.Join(skills.Agents(), ", ")))
+}
+
+func runInit() error {
+	commandName := RootCmd.DisplayName()
+
+	console.Info("Using config %q", configFile)
+	console.Step("Initializing")
+
+	if !config.Install(configFile, commandName, envFile) {
+		return console.Failed(fmt.Errorf("init failed"))
+	}
+
+	if !skills.Install(commandName, agentName) {
+		return console.Failed(fmt.Errorf("init failed"))
+	}
+
+	console.Completed("Init completed")
+	return nil
 }

--- a/docs/gather.md
+++ b/docs/gather.md
@@ -31,6 +31,10 @@ Use "ramenctl gather [command] --help" for more information about a command.
 > [Configuring common options](docs/init.md#configuring-common-options)
 > to learn how to create one.
 
+> [!TIP]
+> Your AI agent can look up applications and run gather commands for
+> you using the skills installed by `ramenctl init`.
+
 ## gather application
 
 The gather application command gathers data for a specific disaster recover

--- a/docs/init.md
+++ b/docs/init.md
@@ -3,33 +3,42 @@
 
 # ramenctl init
 
-The init command crates a configuration file required for other
-*ramenctl* commands.
+The init command creates a configuration file and installs AI agent
+skills for other *ramenctl* commands.
 
 ```console
 % ramenctl init -h
-Create configuration file for your clusters
+Create configuration file and install AI skills
 
 Usage:
   ramenctl init [flags]
 
 Flags:
+  -a, --agent string     AI agent to install skills for (bob, claude, codex, cursor, generic) (default "generic")
       --envfile string   ramen testing environment file
   -h, --help             help for init
 
 Global Flags:
   -c, --config string   configuration file (default "config.yaml")
+      --interactive     enable interactive features (default auto)
 ```
 
-## Creating a configuration file
+## Getting started
 
-The init command creates a configuration file named "config.yaml" in the
-current directory:
+The init command creates a configuration file and installs AI skills
+in the current directory:
 
 ```console
 $ ramenctl init
+⭐ Using config "config.yaml"
 
-✅ Created config file "config.yaml" - please modify for your clusters
+🔎 Initializing ...
+   ✅ Created config file "config.yaml" - please modify for your clusters
+   ✅ Created skills in ".agents/skills/"
+   ✅ Created context file "AGENTS.md"
+      Instruct your agent to read AGENTS.md
+
+✅ Init completed
 ```
 
 > [!IMPORTANT]
@@ -38,6 +47,22 @@ $ ramenctl init
 
 Other *ramenctl* commands use "config.yaml" by default.
 
+### AI skills
+
+`ramenctl init` installs AI agent skills alongside the configuration
+file in the current directory. After running `init`, the directory is
+ready for agentic usage out of the box.
+
+Use the `--agent` (`-a`) flag to install skills in the format expected
+by your AI tool (e.g. `ramenctl init -a cursor`). The default generic
+format works with any agent.
+
+Running `init` again is safe. Existing skill files and context files
+are not overwritten, preserving any user modifications.
+
+For more details on available skills, supported agents, and output
+directory conventions, see [AI Skills](skills.md).
+
 ## Creating configuration file for a ramen testing environment
 
 When using a ramen testing environment we can create a configuration file
@@ -45,9 +70,16 @@ optimized for the testing environment using the `--envfile` option:
 
 ```console
 $ ramenctl init --envfile ../ramen/test/envs/regional-dr.yaml
+⭐ Using config "config.yaml"
 ⭐ Using envfile "../ramen/test/envs/regional-dr.yaml"
 
-✅ Created config file "config.yaml" - please modify for your clusters
+🔎 Initializing ...
+   ✅ Created config file "config.yaml" - please modify for your clusters
+   ✅ Created skills in ".agents/skills/"
+   ✅ Created context file "AGENTS.md"
+      Instruct your agent to read AGENTS.md
+
+✅ Init completed
 ```
 
 You can edit the configuration file to change the default tests.
@@ -62,8 +94,15 @@ Create a configuration file named "myenv.yaml":
 
 ```console
 $ ramenctl init --config myenv.yaml
+⭐ Using config "myenv.yaml"
 
-✅ Created config file "myenv.yaml" - please modify for your clusters
+🔎 Initializing ...
+   ✅ Created config file "myenv.yaml" - please modify for your clusters
+   ✅ Created skills in ".agents/skills/"
+   ✅ Created context file "AGENTS.md"
+      Instruct your agent to read AGENTS.md
+
+✅ Init completed
 ```
 
 To use the configuration file with other commands, specify it with the
@@ -80,6 +119,10 @@ $ ramenctl test run --config myenv.yaml -o test
 
 All *ramenctl* commands require the `clusters` and `clusterSet` options.
 For the validate and gather commands, these are the only options needed.
+
+> [!TIP]
+> You can ask your AI agent to configure the options for your
+> environment using the skills installed by `ramenctl init`.
 
 > [!TIP]
 > When using a ramen testing environment, the `--envfile` option configures

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,116 @@
+<!-- SPDX-FileCopyrightText: The RamenDR authors -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Using ramenctl with AI agents
+
+*ramenctl* is agentic-ready out of the box. Running `ramenctl init`
+installs AI skills that teach your coding assistant how to drive
+*ramenctl* for disaster recovery on your clusters — no extra setup
+needed.
+
+Start with the example session below to see what this feels like in
+practice. After that you'll find the list of available skills, where
+they are installed, and how to add support for a new agent.
+
+## Example session
+
+The following is a short screenplay-style scene: a human and an agent
+use the ramenctl skills. (Monospace block so it reads like a script and
+renders with a distinct background on GitHub and most viewers.)
+
+```text
+INT. CURSOR CHAT — DAY
+
+USER
+        I ran ramenctl init --agent cursor. Help me configure ramenctl
+        for my clusters. My kubeconfigs are in ocp/: hub.yaml is the
+        hub, c1.yaml and c2.yaml are the managed clusters.
+
+AGENT
+        (Edits config.yaml: fills kubeconfigs, reads ClusterClaims on c1
+        and c2, matches names on the hub, sets clusterSet.)
+        Your config is ready.
+
+USER
+        Can you check the clusters?
+
+AGENT
+        (Runs ramenctl validate clusters -o ocp/clusters.)
+        Validation completed (91 ok, 0 warning, 0 problem).
+        (Opens validate-clusters.html in the browser.)
+
+USER
+        Validate an application too.
+
+AGENT
+        (Lists DRPCs on the hub.)
+        I found two applications:
+          1. rbd4 (openshift-dr-ops) — FailedOver
+          2. appset-deploy-rbd (openshift-gitops) — Deployed
+        Which one should I validate?
+
+USER
+        rbd4.
+
+AGENT
+        (Runs ramenctl validate application --name rbd4 --namespace
+        openshift-dr-ops -o ocp/rbd4.)
+        All clear. Opening validate-application.html.
+
+USER
+        You are a very skillful agent!
+
+AGENT
+        Glad it helped.
+```
+
+## Available skills
+
+| Skill                           | Description                                       |
+|---------------------------------|---------------------------------------------------|
+| `ramenctl-init`                 | Create a configuration file for your clusters     |
+| `ramenctl-validate-clusters`    | Validate disaster recovery cluster configuration  |
+| `ramenctl-validate-application` | Validate a DR-protected application               |
+| `ramenctl-gather-application`   | Gather diagnostic data for a protected application|
+| `ramenctl-test-run`             | Run disaster recovery flow tests                  |
+| `ramenctl-test-clean`           | Clean up after test runs                          |
+
+## Where skills are installed
+
+`ramenctl init` installs skills automatically. Use the `--agent` (`-a`)
+flag to install in the format expected by your AI tool:
+
+```console
+$ ramenctl init -a cursor
+```
+
+Supported agents:
+
+| Agent       | Flag          | Skills directory  | Context file                 |
+|-------------|---------------|-------------------|------------------------------|
+| Bob         | `-a bob`      | `.bob/skills/`    | `AGENTS.md`                  |
+| Claude Code | `-a claude`   | `.claude/skills/` | `CLAUDE.md`                  |
+| Codex       | `-a codex`    | `.agents/skills/` | `AGENTS.md`                  |
+| Cursor      | `-a cursor`   | `.cursor/skills/` | `.cursor/rules/ramenctl.mdc` |
+| Generic     | *(default)*   | `.agents/skills/` | `AGENTS.md`                  |
+
+> [!TIP]
+> - When using the generic format, instruct your AI agent to read
+>   `AGENTS.md` for project context and skill discovery.
+> - Bob requires advanced mode to discover skills. Use `/mode advanced`
+>   in the Bob chat before starting.
+
+See [init](init.md) for more on creating the configuration file.
+
+## Adding a new agent
+
+To add support for a new AI agent:
+
+1. Add a constant (e.g. `AgentMyTool = "my-agent"`) in `pkg/skills/agent.go`.
+2. Add an entry to the `agents` map in `pkg/skills/agent.go` with the
+   tool's display name, native skills directory, and context file path.
+3. Create a context file template `pkg/skills/templates/agents/my-agent.tmpl`.
+   The template receives the command name and skill list. Look at existing
+   templates for examples.
+4. Update the agent table in `docs/skills.md`.
+5. Add test cases in `pkg/skills/skills_test.go` for the new agent.

--- a/docs/test.md
+++ b/docs/test.md
@@ -37,6 +37,10 @@ The command supports the following sub-commands:
 > The test command requires a configuration file. See [init](docs/init.md) to
 > learn how to create one.
 
+> [!TIP]
+> Your AI agent can configure tests and run them for you using the
+> skills installed by `ramenctl init`.
+
 ## test run
 
 The run command runs a disaster recovery flow with one or more tiny applications

--- a/docs/test/plan.md
+++ b/docs/test/plan.md
@@ -21,7 +21,13 @@
       1. [Create default config](#create-default-config)
       1. [Create named config](#create-named-config)
       1. [Create config from envfile (upstream only)](#create-config-from-envfile-upstream-only)
+      1. [Init with --agent cursor](#init-with---agent-cursor)
+      1. [Init with --agent claude](#init-with---agent-claude)
+      1. [Init with --agent codex](#init-with---agent-codex)
+      1. [Init with --agent bob](#init-with---agent-bob)
+      1. [Init with invalid --agent](#init-with-invalid---agent)
       1. [Config already exists](#config-already-exists)
+      1. [Re-init is safe](#re-init-is-safe)
    1. [Validate clusters command](#validate-clusters-command)
       1. [Validate fully configured clusters](#validate-fully-configured-clusters)
       1. [Validate clusters ramen not deployed](#validate-clusters-ramen-not-deployed)
@@ -190,7 +196,7 @@ non-zero code.
 
 #### Create default config
 
-**Preconditions:** No `config.yaml` in current directory.
+**Preconditions:** No `config.yaml` or `.agents/skills/` in current directory.
 
 **Steps:**
 
@@ -199,11 +205,26 @@ odf dr init
 ```
 
 **Expected result:**
-- Prints `Created config file "config.yaml" - please modify for your clusters`.
+
+```
+⭐ Using config "config.yaml"
+
+🔎 Initializing ...
+   ✅ Created config file "config.yaml" - please modify for your clusters
+   ✅ Created skills in ".agents/skills/"
+   ✅ Created context file "AGENTS.md"
+      Instruct your agent to read AGENTS.md
+
+✅ Init completed
+```
+
 - File `config.yaml` is created with documented sections: `clusters`, `repo`,
   `drPolicy`, `clusterSet`, `pvcSpecs`, `deployers`, `tests`.
 - File contains helpful comments explaining each section.
-- File includes notes about options that user may need to modify
+- File includes notes about options that user may need to modify.
+- Directory `.agents/skills/` is created with one subdirectory per subcommand,
+  each containing a `SKILL.md` file.
+- File `AGENTS.md` is created with project overview and skill index.
 
 #### Create named config
 
@@ -218,6 +239,7 @@ odf dr init --config myenv.yaml
 **Expected result:**
 - Prints `Created config file "myenv.yaml" - please modify for your clusters`.
 - File `myenv.yaml` is created.
+- Skills are installed in `.agents/skills/` and `AGENTS.md` is created.
 
 #### Create config from envfile (upstream only)
 
@@ -231,7 +253,140 @@ ramenctl init --envfile ../ramen/test/envs/regional-dr.yaml
 
 **Expected result:**
 - Prints the envfile path and success message.
-- `config.yaml` is populated with cluster names, storage class names and distro relevant to ramen testing environment.
+- `config.yaml` is populated with cluster names, storage class names and
+  distro relevant to ramen testing environment.
+- Skills are installed in `.agents/skills/` and `AGENTS.md` is created.
+
+#### Init with --agent cursor
+
+**Preconditions:** No `config.yaml` or `.cursor/skills/` in current directory.
+
+**Steps:**
+
+```bash
+odf dr init -a cursor
+```
+
+**Expected result:**
+
+```
+⭐ Using config "config.yaml"
+
+🔎 Initializing ...
+   ✅ Created config file "config.yaml" - please modify for your clusters
+   ✅ Created skills for Cursor in ".cursor/skills/"
+   ✅ Created context file ".cursor/rules/ramenctl.mdc"
+
+✅ Init completed
+```
+
+- Skills are installed in `.cursor/skills/` with one subdirectory per
+  subcommand (e.g., `odf-dr-init/SKILL.md`).
+- Each skill file contains YAML frontmatter with Cursor metadata.
+- Skill content uses `odf dr` as the command name.
+- Context file `.cursor/rules/ramenctl.mdc` is created with `alwaysApply: true`.
+
+#### Init with --agent claude
+
+**Preconditions:** No `config.yaml` or `.claude/skills/` in current directory.
+
+**Steps:**
+
+```bash
+odf dr init -a claude
+```
+
+**Expected result:**
+
+```
+⭐ Using config "config.yaml"
+
+🔎 Initializing ...
+   ✅ Created config file "config.yaml" - please modify for your clusters
+   ✅ Created skills for Claude Code in ".claude/skills/"
+   ✅ Created context file "CLAUDE.md"
+
+✅ Init completed
+```
+
+- Skills are installed in `.claude/skills/` with one subdirectory per
+  subcommand, each containing a `SKILL.md` file.
+- File `CLAUDE.md` is created with project overview.
+
+#### Init with --agent codex
+
+**Preconditions:** No `config.yaml` or `.agents/skills/` in current directory.
+
+**Steps:**
+
+```bash
+odf dr init -a codex
+```
+
+**Expected result:**
+
+```
+⭐ Using config "config.yaml"
+
+🔎 Initializing ...
+   ✅ Created config file "config.yaml" - please modify for your clusters
+   ✅ Created skills for Codex in ".agents/skills/"
+   ✅ Created context file "AGENTS.md"
+
+✅ Init completed
+```
+
+- Skills are installed in `.agents/skills/` with one subdirectory per
+  subcommand, each containing a `SKILL.md` file.
+- File `AGENTS.md` is created with project overview.
+
+#### Init with --agent bob
+
+**Preconditions:** No `config.yaml` or `.bob/skills/` in current directory.
+
+**Steps:**
+
+```bash
+odf dr init -a bob
+```
+
+**Expected result:**
+
+```
+⭐ Using config "config.yaml"
+
+🔎 Initializing ...
+   ✅ Created config file "config.yaml" - please modify for your clusters
+   ✅ Created skills for Bob in ".bob/skills/"
+   ✅ Created context file "AGENTS.md"
+      Use "/mode advanced" in Bob to enable skills
+
+✅ Init completed
+```
+
+- Skills are installed in `.bob/skills/` with one subdirectory per
+  subcommand, each containing a `SKILL.md` file.
+- File `AGENTS.md` is created with project overview.
+
+#### Init with invalid --agent
+
+**Steps:**
+
+```bash
+odf dr init -a vim
+```
+
+**Expected result:**
+
+```
+Error: unknown agent tool "vim" (choose from: bob, claude, codex, cursor, generic)
+Usage:
+  odf dr init [flags]
+...
+```
+
+- Command fails immediately with usage help.
+- No config file or skills are created.
 
 #### Config already exists
 
@@ -243,8 +398,53 @@ ramenctl init --envfile ../ramen/test/envs/regional-dr.yaml
 odf dr init
 ```
 
-**Expected result:** Error indicating the file already exists. Does not
-overwrite the existing file.
+**Expected result:**
+
+```
+⭐ Using config "config.yaml"
+
+🔎 Initializing ...
+   ⚠️ Configuration file "config.yaml" already exists
+   ✅ Created skills in ".agents/skills/"
+   ✅ Created context file "AGENTS.md"
+      Instruct your agent to read AGENTS.md
+
+✅ Init completed
+```
+
+- Existing config file is not overwritten.
+- Skills and context file are installed.
+- Command succeeds.
+
+#### Re-init is safe
+
+**Preconditions:** `odf dr init` was already run. Config file, skills,
+and context file all exist.
+
+**Steps:**
+
+```bash
+odf dr init
+```
+
+**Expected result:**
+
+```
+⭐ Using config "config.yaml"
+
+🔎 Initializing ...
+   ⚠️ Configuration file "config.yaml" already exists
+   ⚠️ Skills already exist in ".agents/skills/"
+   ⚠️ Context file "AGENTS.md" already exists
+      Instruct your agent to read AGENTS.md
+
+✅ Init completed
+```
+
+- Existing files are not overwritten, preserving user modifications.
+- Command succeeds with warnings.
+- To update skills after upgrading, delete the skills directory and
+  re-run `init`.
 
 
 ### Validate clusters command

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -38,6 +38,10 @@ The command supports the following sub-commands:
 > [Configuring common options](docs/init.md#configuring-common-options)
 > to learn how to create one.
 
+> [!TIP]
+> Your AI agent can look up applications and run validate commands for
+> you using the skills installed by `ramenctl init`.
+
 ## validate application
 
 The validate application command validates a specific DR-protected application

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,9 +32,25 @@ type Config struct {
 	Namespaces config.Namespaces `json:"namespaces"`
 }
 
-// CreateSampleConfig create a sample config that can be used by all commands. The file can be
+// Install creates a sample config file. Returns true on success or if the file
+// already exists.
+func Install(filename, commandName, envFile string) bool {
+	err := createSampleConfig(filename, commandName, envFile)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			console.Warn("Configuration file %q already exists", filename)
+			return true
+		}
+		console.Error("%s", err)
+		return false
+	}
+	console.Pass("Created config file %q - please modify for your clusters", filename)
+	return true
+}
+
+// createSampleConfig creates a sample config that can be used by all commands. The file can be
 // parsed using ReadConfig() or test.readConfig().
-func CreateSampleConfig(filename, commandName, envFile string) error {
+func createSampleConfig(filename, commandName, envFile string) error {
 	var sample *Sample
 	if envFile != "" {
 		console.Info("Using envfile %q", envFile)
@@ -54,14 +70,14 @@ func CreateSampleConfig(filename, commandName, envFile string) error {
 
 	if err := createFile(filename, content); err != nil {
 		if errors.Is(err, os.ErrExist) {
-			return fmt.Errorf("configuration file %q already exists", filename)
+			return fmt.Errorf("configuration file %q already exists: %w", filename, err)
 		}
 		return fmt.Errorf("failed to create %q: %w", filename, err)
 	}
 	return nil
 }
 
-// ReadConfig reads the configuration file created by CreateSampleConfig, ignoring the test only
+// ReadConfig reads the configuration file created by Install, ignoring the test only
 // configuration.
 func ReadConfig(filename string) (*Config, error) {
 	viper.SetDefault("ClusterSet", config.DefaultClusterSetName)

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -26,6 +26,15 @@ func Pass(format string, args ...any) {
 	fmt.Printf("   ✅ "+format+"\n", args...)
 }
 
+// Warn logs a non-fatal warning for a single operation.
+func Warn(format string, args ...any) {
+	// ⚠️ is two Unicode code points: ⚠ (U+26A0) + variation selector (U+FE0F).
+	// The variation selector forces color emoji rendering but consumes one
+	// visual cell in some terminals (e.g. macOS Terminal.app), so we add an
+	// extra space to align with single code point emojis like ✅.
+	fmt.Fprintf(os.Stderr, "   ⚠️  "+format+"\n", args...)
+}
+
 // Error logs single operation error.
 func Error(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "   ❌ "+format+"\n", args...)
@@ -39,6 +48,11 @@ func Completed(format string, args ...any) {
 // Hint logs a suggestion to the user, indented under the previous message.
 func Hint(format string, args ...any) {
 	fmt.Printf("   "+format+"\n", args...)
+}
+
+// StepHint logs a suggestion indented under a step-level message (Pass/Warn/Error).
+func StepHint(format string, args ...any) {
+	fmt.Printf("      "+format+"\n", args...)
 }
 
 // Failed logs command failure and returns a generic error to signal failure without duplicating

--- a/pkg/skills/agent.go
+++ b/pkg/skills/agent.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// Supported agent tool names.
+const (
+	AgentCursor  = "cursor"
+	AgentClaude  = "claude"
+	AgentCodex   = "codex"
+	AgentBob     = "bob"
+	AgentGeneric = "generic"
+)
+
+type agent struct {
+	Name        string
+	DisplayName string
+	SkillsDir   string
+	ContextFile string
+	Hint        string
+}
+
+var agents = map[string]agent{
+	AgentCursor: {
+		Name:        AgentCursor,
+		DisplayName: "Cursor",
+		SkillsDir:   ".cursor/skills",
+		ContextFile: ".cursor/rules/ramenctl.mdc",
+	},
+	AgentClaude: {
+		Name:        AgentClaude,
+		DisplayName: "Claude Code",
+		SkillsDir:   ".claude/skills",
+		ContextFile: "CLAUDE.md",
+	},
+	AgentCodex: {
+		Name:        AgentCodex,
+		DisplayName: "Codex",
+		SkillsDir:   ".agents/skills",
+		ContextFile: "AGENTS.md",
+	},
+	AgentBob: {
+		Name:        AgentBob,
+		DisplayName: "Bob",
+		SkillsDir:   ".bob/skills",
+		ContextFile: ".bob/rules/ramenctl.md",
+		Hint:        `Use "/mode advanced" in Bob to enable skills`,
+	},
+	AgentGeneric: {
+		Name:        AgentGeneric,
+		SkillsDir:   ".agents/skills",
+		ContextFile: "AGENTS.md",
+		Hint:        "Instruct your agent to read AGENTS.md",
+	},
+}
+
+// Agents returns sorted list of supported agent names.
+func Agents() []string {
+	return slices.Sorted(maps.Keys(agents))
+}
+
+// ValidateAgent returns an error if agent is not a supported agent tool name.
+func ValidateAgent(agent string) error {
+	if _, ok := agents[agent]; !ok {
+		return fmt.Errorf(
+			"unknown agent tool %q (choose from: %s)",
+			agent, strings.Join(Agents(), ", "),
+		)
+	}
+	return nil
+}

--- a/pkg/skills/install.go
+++ b/pkg/skills/install.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ramendr/ramenctl/pkg/console"
+)
+
+// Install installs AI skills for the given agent tool. Returns true on success.
+func Install(commandName, agentName string) bool {
+	agent, ok := agents[agentName]
+	if !ok {
+		panic(fmt.Sprintf("unknown agent tool %q: call ValidateAgent first", agentName))
+	}
+
+	cmd := Command{
+		Name: commandName,
+		Slug: directoryName(commandName),
+	}
+
+	if !installSkills(cmd, agent) {
+		return false
+	}
+
+	return installContextFile(cmd, agent)
+}
+
+func installSkills(cmd Command, agent agent) bool {
+	if err := os.MkdirAll(agent.SkillsDir, 0o755); err != nil {
+		console.Error("failed to create directory %q: %s", agent.SkillsDir, err)
+		return false
+	}
+
+	var skipped []string
+
+	for _, skill := range skills {
+		skillDir := filepath.Join(agent.SkillsDir, cmd.Slug+"-"+skill.Name)
+
+		if err := os.Mkdir(skillDir, 0o755); err != nil {
+			if !errors.Is(err, os.ErrExist) {
+				console.Error("failed to create directory %q: %s", skillDir, err)
+				return false
+			}
+			if !isDir(skillDir) {
+				console.Error("expected directory but found file %q", skillDir)
+				return false
+			}
+		}
+
+		content, err := renderSkill(skill, cmd)
+		if err != nil {
+			console.Error("%s", err)
+			return false
+		}
+
+		skillFile := filepath.Join(skillDir, "SKILL.md")
+		if err := writeNewFile(skillFile, content); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				skipped = append(skipped, cmd.Slug+"-"+skill.Name)
+				continue
+			}
+			console.Error("failed to write %q: %s", skillFile, err)
+			return false
+		}
+	}
+
+	switch {
+	case len(skipped) == len(skills):
+		console.Warn("Skills already exist in \"%s/\"", agent.SkillsDir)
+	case len(skipped) > 0:
+		if agent.DisplayName != "" {
+			console.Warn("Created skills for %s in \"%s/\"", agent.DisplayName, agent.SkillsDir)
+		} else {
+			console.Warn("Created skills in \"%s/\"", agent.SkillsDir)
+		}
+		console.StepHint("Skipped existing skills %s", strings.Join(skipped, ", "))
+	default:
+		if agent.DisplayName != "" {
+			console.Pass("Created skills for %s in \"%s/\"", agent.DisplayName, agent.SkillsDir)
+		} else {
+			console.Pass("Created skills in \"%s/\"", agent.SkillsDir)
+		}
+	}
+
+	return true
+}
+
+func installContextFile(cmd Command, agent agent) bool {
+	content, err := renderContextFile(cmd, agent)
+	if err != nil {
+		console.Error("%s", err)
+		return false
+	}
+
+	dir := filepath.Dir(agent.ContextFile)
+	if dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			console.Error("failed to create directory %q: %s", dir, err)
+			return false
+		}
+	}
+
+	if err := writeNewFile(agent.ContextFile, content); err != nil {
+		if errors.Is(err, os.ErrExist) && isRegularFile(agent.ContextFile) {
+			console.Warn("Context file %q already exists", agent.ContextFile)
+		} else {
+			console.Error("failed to write %q: %s", agent.ContextFile, err)
+			return false
+		}
+	} else {
+		console.Pass("Created context file %q", agent.ContextFile)
+	}
+
+	if agent.Hint != "" {
+		console.StepHint("%s", agent.Hint)
+	}
+
+	return true
+}
+
+func isRegularFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// writeNewFile creates a file only if it does not exist. Returns os.ErrExist
+// if the file already exists, matching the write-once ownership model.
+func writeNewFile(path string, content []byte) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o640)
+	if err != nil {
+		return err
+	}
+	// Closing twice is safe; defer handles the error path, explicit close
+	// below catches flush errors on the happy path.
+	defer f.Close()
+
+	if _, err := f.Write(content); err != nil {
+		return err
+	}
+
+	return f.Close()
+}

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+//go:embed templates
+var skillsFS embed.FS
+
+// Command identifies the CLI command for skill templates.
+type Command struct {
+	// Name is the display name (e.g., "ramenctl", "odf dr").
+	Name string
+	// Slug is the directory-safe form (e.g., "ramenctl", "odf-dr").
+	Slug string
+}
+
+// Skill holds metadata about one embedded skill template.
+type Skill struct {
+	// Name is the subcommand name (e.g., "init", "validate-clusters").
+	Name string
+	// Description is a short one-line summary of the skill.
+	Description string
+}
+
+// skills is the static list of all embedded skills.
+var skills = []Skill{
+	{Name: "gather-application", Description: "Gather diagnostic data for an application"},
+	{Name: "init", Description: "Configure for your clusters"},
+	{Name: "test-clean", Description: "Clean up after test runs"},
+	{Name: "test-run", Description: "Run disaster recovery flow tests"},
+	{Name: "validate-application", Description: "Validate a DR-protected application"},
+	{Name: "validate-clusters", Description: "Validate DR cluster configuration"},
+}
+
+// skillData is the data passed to skill templates.
+type skillData struct {
+	Command Command
+	Skill   Skill
+}
+
+func renderSkill(skill Skill, cmd Command) ([]byte, error) {
+	tmplPath := "templates/skills/" + skill.Name + ".tmpl"
+
+	content, err := skillsFS.ReadFile(tmplPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read skill template %q: %w", skill.Name, err)
+	}
+
+	t, err := template.New(skill.Name).Parse(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse skill template %q: %w", skill.Name, err)
+	}
+
+	data := skillData{Command: cmd, Skill: skill}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("failed to render skill template %q: %w", skill.Name, err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// contextData is the data passed to agent context templates.
+type contextData struct {
+	Command Command
+	Agent   agent
+	Skills  []Skill
+}
+
+func renderContextFile(cmd Command, ag agent) ([]byte, error) {
+	tmplPath := "templates/agents/" + ag.Name + ".tmpl"
+
+	content, err := skillsFS.ReadFile(tmplPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read context template %q: %w", ag.Name, err)
+	}
+
+	t, err := template.New(ag.Name).Parse(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse context template %q: %w", ag.Name, err)
+	}
+
+	data := contextData{
+		Command: cmd,
+		Agent:   ag,
+		Skills:  skills,
+	}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("failed to render context template %q: %w", ag.Name, err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// directoryName converts a command name to a form suitable for directory names
+// ("odf dr" -> "odf-dr").
+func directoryName(name string) string {
+	return strings.ReplaceAll(name, " ", "-")
+}

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -1,0 +1,330 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package skills_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ramendr/ramenctl/pkg/skills"
+)
+
+var expectedSkills = []string{
+	"gather-application",
+	"init",
+	"test-clean",
+	"test-run",
+	"validate-application",
+	"validate-clusters",
+}
+
+// Install per agent.
+
+func TestInstallGeneric(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if !skills.Install("ramenctl", skills.AgentGeneric) {
+		t.Fatal("install failed")
+	}
+
+	validateSkills(t, ".agents/skills", "ramenctl")
+	validateContextFile(t, "AGENTS.md", "ramenctl")
+	validateContextSkillIndex(t, "AGENTS.md", ".agents/skills", "ramenctl")
+}
+
+func TestInstallCursor(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if !skills.Install("ramenctl", skills.AgentCursor) {
+		t.Fatal("install failed")
+	}
+
+	validateSkills(t, ".cursor/skills", "ramenctl")
+	validateContextFile(t, ".cursor/rules/ramenctl.mdc", "ramenctl")
+	assertContextContains(t, ".cursor/rules/ramenctl.mdc", "alwaysApply: true")
+}
+
+func TestInstallClaude(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if !skills.Install("ramenctl", skills.AgentClaude) {
+		t.Fatal("install failed")
+	}
+
+	validateSkills(t, ".claude/skills", "ramenctl")
+	validateContextFile(t, "CLAUDE.md", "ramenctl")
+}
+
+func TestInstallCodex(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if !skills.Install("ramenctl", skills.AgentCodex) {
+		t.Fatal("install failed")
+	}
+
+	validateSkills(t, ".agents/skills", "ramenctl")
+	validateContextFile(t, "AGENTS.md", "ramenctl")
+}
+
+func TestInstallBob(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if !skills.Install("ramenctl", skills.AgentBob) {
+		t.Fatal("install failed")
+	}
+
+	validateSkills(t, ".bob/skills", "ramenctl")
+	validateContextFile(t, ".bob/rules/ramenctl.md", "ramenctl")
+	assertContextContains(t, ".bob/rules/ramenctl.md", "advanced mode")
+}
+
+// Command name substitution.
+
+func TestInstallCommandName(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if !skills.Install("odf dr", skills.AgentCursor) {
+		t.Fatal("install failed")
+	}
+
+	validateSkills(t, ".cursor/skills", "odf-dr")
+	validateContextFile(t, ".cursor/rules/ramenctl.mdc", "odf dr")
+	assertContextContains(t, ".cursor/skills/odf-dr-init/SKILL.md", "odf dr")
+}
+
+// Skills write-once.
+
+func TestInstallAllSkipped(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if !skills.Install("ramenctl", skills.AgentGeneric) {
+		t.Fatal("first install failed")
+	}
+
+	// Append to a skill file to simulate user changes.
+	path := filepath.Join(".agents", "skills", "ramenctl-init", "SKILL.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content = append(content, "\n# User notes\n"...)
+	if err := os.WriteFile(path, content, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second install should succeed but not overwrite existing files.
+	if !skills.Install("ramenctl", skills.AgentGeneric) {
+		t.Fatal("second install failed")
+	}
+
+	validateSkills(t, ".agents/skills", "ramenctl")
+
+	content, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "# User notes") {
+		t.Error("install should not overwrite existing skill files")
+	}
+}
+
+func TestInstallSomeSkipped(t *testing.T) {
+	for _, tt := range []struct {
+		agent     string
+		skillsDir string
+	}{
+		{skills.AgentGeneric, ".agents/skills"},
+		{skills.AgentCursor, ".cursor/skills"},
+	} {
+		t.Run(tt.agent, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+
+			if !skills.Install("ramenctl", tt.agent) {
+				t.Fatal("first install failed")
+			}
+
+			if err := os.RemoveAll(filepath.Join(tt.skillsDir, "ramenctl-init")); err != nil {
+				t.Fatal(err)
+			}
+
+			if !skills.Install("ramenctl", tt.agent) {
+				t.Fatal("second install failed")
+			}
+
+			validateSkills(t, tt.skillsDir, "ramenctl")
+		})
+	}
+}
+
+func TestInstallEmptySkillDir(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := os.MkdirAll(".agents/skills/ramenctl-init", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if !skills.Install("ramenctl", skills.AgentGeneric) {
+		t.Fatal("install failed")
+	}
+
+	validateSkills(t, ".agents/skills", "ramenctl")
+}
+
+// Skills failures.
+
+func TestInstallSkillsDirFailure(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := os.WriteFile(".agents", []byte("block"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if skills.Install("ramenctl", skills.AgentGeneric) {
+		t.Fatal("install should fail when skills parent directory cannot be created")
+	}
+}
+
+func TestInstallSkillsFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod does not restrict directory writes on Windows")
+	}
+	t.Chdir(t.TempDir())
+
+	if err := os.MkdirAll(".agents/skills", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(".agents/skills", 0o555); err != nil {
+		t.Fatal(err)
+	}
+	if skills.Install("ramenctl", skills.AgentGeneric) {
+		t.Fatal("install should fail when skills directory is not writable")
+	}
+}
+
+func TestInstallSkillFileInsteadOfDir(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := os.MkdirAll(".agents/skills", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(".agents/skills/ramenctl-init", []byte("not a dir"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if skills.Install("ramenctl", skills.AgentGeneric) {
+		t.Fatal("install should fail when skill path is a file instead of directory")
+	}
+}
+
+// Context file failures.
+
+func TestInstallContextFileDirFailure(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := os.MkdirAll(".cursor", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(".cursor", "rules"), []byte("block"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if skills.Install("ramenctl", skills.AgentCursor) {
+		t.Fatal("install should fail when context file directory cannot be created")
+	}
+}
+
+func TestInstallContextFileWriteFailure(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := os.MkdirAll("AGENTS.md", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if skills.Install("ramenctl", skills.AgentGeneric) {
+		t.Fatal("install should fail when context file path is a directory")
+	}
+}
+
+// Agent validation.
+
+func TestValidateAgent(t *testing.T) {
+	for _, agent := range []string{
+		skills.AgentCursor, skills.AgentClaude, skills.AgentCodex, skills.AgentBob, skills.AgentGeneric,
+	} {
+		if err := skills.ValidateAgent(agent); err != nil {
+			t.Errorf("unexpected error for agent %q: %v", agent, err)
+		}
+	}
+	if err := skills.ValidateAgent("invalid"); err == nil {
+		t.Fatal("expected error for invalid agent")
+	}
+}
+
+// Helpers.
+
+func assertContextContains(t *testing.T, path, expected string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), expected) {
+		t.Errorf("%s should contain %q", path, expected)
+	}
+}
+
+func validateContextFile(t *testing.T, path, commandName string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("missing context file %s: %v", path, err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "# "+commandName) {
+		t.Errorf("%s should contain %q heading", path, commandName)
+	}
+	if strings.Contains(text, "{{") {
+		t.Errorf("%s should not contain template syntax", path)
+	}
+}
+
+func validateContextSkillIndex(t *testing.T, path, skillsDir, commandSlug string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("missing context file %s: %v", path, err)
+	}
+	text := string(content)
+	for _, name := range expectedSkills {
+		entry := skillsDir + "/" + commandSlug + "-" + name + "/SKILL.md"
+		if !strings.Contains(text, entry) {
+			t.Errorf("%s should contain skill index entry %q", path, entry)
+		}
+	}
+}
+
+func validateSkills(t *testing.T, skillsDir, commandSlug string) {
+	t.Helper()
+	for _, name := range expectedSkills {
+		path := filepath.Join(skillsDir, commandSlug+"-"+name, "SKILL.md")
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("missing %s: %v", path, err)
+			continue
+		}
+		text := string(content)
+		if !strings.HasPrefix(text, "---\n") {
+			t.Errorf("%s should have frontmatter", path)
+		}
+		if !strings.Contains(text, "name: "+commandSlug+"-"+name) {
+			t.Errorf("%s should contain skill name in frontmatter", path)
+		}
+		if strings.Contains(text, "{{") {
+			t.Errorf("%s should not contain template syntax", path)
+		}
+	}
+}

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -96,6 +96,19 @@ func TestInstallCommandName(t *testing.T) {
 	assertContextContains(t, ".cursor/skills/odf-dr-init/SKILL.md", "odf dr")
 }
 
+func TestValidateClustersUsesExistingConfig(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if !skills.Install("ramenctl", skills.AgentBob) {
+		t.Fatal("install failed")
+	}
+
+	path := ".bob/skills/ramenctl-validate-clusters/SKILL.md"
+	assertContextContains(t, path, "If `config.yaml` already exists, do not run `ramenctl init`")
+	assertContextContains(t, path, "If no config file exists, stop and ask the user to complete the")
+	assertContextContains(t, path, "ramenctl-init workflow first")
+}
+
 // Skills write-once.
 
 func TestInstallAllSkipped(t *testing.T) {

--- a/pkg/skills/templates/agents/bob.tmpl
+++ b/pkg/skills/templates/agents/bob.tmpl
@@ -1,0 +1,15 @@
+{{- /* SPDX-FileCopyrightText: The RamenDR authors */ -}}
+{{- /* SPDX-License-Identifier: Apache-2.0 */ -}}
+# {{.Command.Name}}
+
+`{{.Command.Name}}` manages disaster recovery for OpenShift and Kubernetes
+clusters. When the user asks for help with a `{{.Command.Name}}` task,
+read the matching skill file before responding. Skills contain required
+steps, flags, and expected output that you need to follow.
+
+Run `{{.Command.Name}} init` to create a configuration file, then use
+`validate`, `gather`, and `test` commands.
+
+## Important
+
+Switch to advanced mode to discover the {{.Command.Name}} skills.

--- a/pkg/skills/templates/agents/bob.tmpl
+++ b/pkg/skills/templates/agents/bob.tmpl
@@ -3,12 +3,17 @@
 # {{.Command.Name}}
 
 `{{.Command.Name}}` manages disaster recovery for OpenShift and Kubernetes
-clusters. When the user asks for help with a `{{.Command.Name}}` task,
-read the matching skill file before responding. Skills contain required
-steps, flags, and expected output that you need to follow.
+clusters.
 
-Run `{{.Command.Name}} init` to create a configuration file, then use
-`validate`, `gather`, and `test` commands.
+## Critical workflow rule
+
+BEFORE taking ANY action on a {{.Command.Name}} task, you MUST:
+1. Identify which ramenctl command the user needs (init, validate, gather, test)
+2. Read the corresponding skill file from .bob/skills/{{.Command.Slug}}-COMMAND/SKILL.md
+3. Follow the exact steps, flags, and workflow documented in the skill
+
+Skills contain required steps, flags, expected output, and troubleshooting
+guidance that you need to follow precisely.
 
 ## Important
 

--- a/pkg/skills/templates/agents/claude.tmpl
+++ b/pkg/skills/templates/agents/claude.tmpl
@@ -1,0 +1,11 @@
+{{- /* SPDX-FileCopyrightText: The RamenDR authors */ -}}
+{{- /* SPDX-License-Identifier: Apache-2.0 */ -}}
+# {{.Command.Name}}
+
+`{{.Command.Name}}` manages disaster recovery for OpenShift and Kubernetes
+clusters. When the user asks for help with a `{{.Command.Name}}` task,
+read the matching skill file before responding. Skills contain required
+steps, flags, and expected output that you need to follow.
+
+Run `{{.Command.Name}} init` to create a configuration file, then use
+`validate`, `gather`, and `test` commands.

--- a/pkg/skills/templates/agents/codex.tmpl
+++ b/pkg/skills/templates/agents/codex.tmpl
@@ -1,0 +1,11 @@
+{{- /* SPDX-FileCopyrightText: The RamenDR authors */ -}}
+{{- /* SPDX-License-Identifier: Apache-2.0 */ -}}
+# {{.Command.Name}}
+
+`{{.Command.Name}}` manages disaster recovery for OpenShift and Kubernetes
+clusters. When the user asks for help with a `{{.Command.Name}}` task,
+read the matching skill file before responding. Skills contain required
+steps, flags, and expected output that you need to follow.
+
+Run `{{.Command.Name}} init` to create a configuration file, then use
+`validate`, `gather`, and `test` commands.

--- a/pkg/skills/templates/agents/cursor.tmpl
+++ b/pkg/skills/templates/agents/cursor.tmpl
@@ -1,0 +1,16 @@
+{{- /* SPDX-FileCopyrightText: The RamenDR authors */ -}}
+{{- /* SPDX-License-Identifier: Apache-2.0 */ -}}
+---
+description: Overview of {{.Command.Name}} for disaster recovery.
+alwaysApply: true
+---
+
+# {{.Command.Name}}
+
+`{{.Command.Name}}` manages disaster recovery for OpenShift and Kubernetes
+clusters. When the user asks for help with a `{{.Command.Name}}` task,
+read the matching skill file before responding. Skills contain required
+steps, flags, and expected output that you need to follow.
+
+Run `{{.Command.Name}} init` to create a configuration file, then use
+`validate`, `gather`, and `test` commands.

--- a/pkg/skills/templates/agents/generic.tmpl
+++ b/pkg/skills/templates/agents/generic.tmpl
@@ -1,0 +1,16 @@
+{{- /* SPDX-FileCopyrightText: The RamenDR authors */ -}}
+{{- /* SPDX-License-Identifier: Apache-2.0 */ -}}
+# {{.Command.Name}}
+
+`{{.Command.Name}}` manages disaster recovery for OpenShift and Kubernetes
+clusters. When the user asks for help with a `{{.Command.Name}}` task,
+read the matching skill file before responding. Skills contain required
+steps, flags, and expected output that you need to follow.
+
+## Skills
+
+Skills are detailed guides stored in `{{.Agent.SkillsDir}}/`. When a task
+matches a skill below, read the corresponding `SKILL.md` file.
+{{range .Skills}}
+- `{{$.Agent.SkillsDir}}/{{$.Command.Slug}}-{{.Name}}/SKILL.md` - {{.Description}}
+{{- end}}

--- a/pkg/skills/templates/skills/gather-application.tmpl
+++ b/pkg/skills/templates/skills/gather-application.tmpl
@@ -1,0 +1,111 @@
+{{- /* SPDX-FileCopyrightText: The RamenDR authors */ -}}
+{{- /* SPDX-License-Identifier: Apache-2.0 */ -}}
+---
+name: {{.Command.Slug}}-{{.Skill.Name}}
+description: >-
+  Gather diagnostic data for a DR-protected application using
+  {{.Command.Name}} gather application. Use when the user wants to collect
+  data for troubleshooting, create a bug report, or inspect application
+  resources across clusters.
+---
+
+# {{.Command.Name}} gather application
+
+Gather data for a specific DR-protected application across the hub, managed
+clusters, and S3 storage. Unlike `{{.Command.Name}} validate application`,
+this command only collects data without validating it.
+
+## Requirements
+
+- A configuration file with cluster kubeconfigs (see {{.Command.Slug}}-init skill)
+- At least one DR-protected application in the clusters
+
+## Workflow
+
+### Step 1: Look up protected applications
+
+List DRPCs on the hub using the hub kubeconfig from the {{.Command.Name}} config file:
+
+```console
+$ kubectl get drpc -A --kubeconfig <hub-kubeconfig>
+NAMESPACE   NAME                   AGE   PREFERREDCLUSTER   FAILOVERCLUSTER   DESIREDSTATE   CURRENTSTATE
+argocd      appset-deploy-rbd      69m   dr1                dr2               Relocate       Relocated
+```
+
+Present the list and let the user choose which application to gather
+data for.
+
+### Step 2: Run gather application
+
+Use `<env>/<namespace>-<app-name>` for the output directory, e.g., `myenv/myns-myapp`.
+
+```console
+$ {{.Command.Name}} gather application --name <drpc-name> --namespace <namespace> -o <output-dir>
+```
+
+Use `--config <file>` if the config file is not the default `config.yaml`.
+
+The command takes a few seconds on local clusters and about a minute on
+remote clusters.
+
+### Step 3: Check the result
+
+On success the command ends with:
+
+```console
+✅ Gather completed
+```
+
+On failure, check `<output-dir>/gather-application.log` for details.
+
+### Step 4: Inspect gathered data
+
+The output directory contains:
+
+| File | Purpose |
+|------|---------|
+| `gather-application.yaml` | Report describing the gather operation |
+| `gather-application.log` | Detailed log |
+| `gather-application.data/` | Gathered resources |
+
+#### Gathered data structure
+
+One directory per cluster plus `s3/`. Each cluster directory has
+`cluster/` for cluster-scoped resources and `namespaces/` for namespaced
+resources. Ramen operator logs are gathered under
+`namespaces/ramen-system/pods/`.
+
+```console
+$ tree -L3 <output-dir>/gather-application.data
+gather-application.data/
+├── dr1/
+│   ├── cluster/
+│   │   ├── namespaces/
+│   │   ├── persistentvolumes/
+│   │   └── storage.k8s.io/
+│   └── namespaces/
+│       ├── test-appset-deploy-rbd/
+│       └── ramen-system/
+├── dr2/
+│   ├── cluster/
+│   └── namespaces/
+│       ├── test-appset-deploy-rbd/
+│       └── ramen-system/
+├── hub/
+│   ├── cluster/
+│   └── namespaces/
+│       ├── argocd/
+│       └── ramen-system/
+└── s3/
+    ├── minio-on-dr1/
+    │   └── test-appset-deploy-rbd/
+    └── minio-on-dr2/
+        └── test-appset-deploy-rbd/
+```
+
+## Notes
+
+- To report DR issues, archive the entire output directory and upload it
+  to the issue tracker.
+- Use `{{.Command.Name}} validate application` if you need both data collection
+  and problem detection.

--- a/pkg/skills/templates/skills/init.tmpl
+++ b/pkg/skills/templates/skills/init.tmpl
@@ -1,0 +1,202 @@
+{{- /* SPDX-FileCopyrightText: The RamenDR authors */ -}}
+{{- /* SPDX-License-Identifier: Apache-2.0 */ -}}
+---
+name: {{.Command.Slug}}-{{.Skill.Name}}
+description: >-
+  Configure a {{.Command.Name}} configuration file for disaster recovery
+  clusters. Use when the user wants to set up kubeconfigs, configure
+  clusterSet, or edit test options in the config file.
+---
+
+# {{.Command.Name}} init
+
+Help the user configure `config.yaml` created by `{{.Command.Name}} init`.
+The config file is required by all other {{.Command.Name}} commands.
+
+## Workflow
+
+### Step 1: Ask the user about their environment
+
+The user has already run `{{.Command.Name}} init` which created `config.yaml`
+(or a custom name with `--config`). Ask:
+- Where are their kubeconfig files? The user must specify which
+  kubeconfig is the hub and which are the managed clusters (c1, c2).
+
+### Step 2: Configure clusters
+
+Open `config.yaml` and help the user set the kubeconfig paths:
+
+```yaml
+clusters:
+  hub:
+    kubeconfig: my-hub.yaml
+  passive-hub:
+    kubeconfig: ""
+  c1:
+    kubeconfig: my-c1.yaml
+  c2:
+    kubeconfig: my-c2.yaml
+```
+
+Set `passive-hub` kubeconfig for optional passive hub cluster, or leave
+empty if not using passive hub.
+
+### Step 3: Discover and configure clusterSet
+
+The clusterSet can be discovered automatically using the kubeconfigs from
+step 2. Follow this procedure:
+
+#### 3a. Get the OCM cluster names for c1 and c2
+
+Kubernetes does not have a built-in cluster name concept. In OCM, each
+managed cluster reports its name via a `ClusterClaim` resource. Get the
+OCM name from each managed cluster:
+
+```console
+$ kubectl get clusterclaim name --kubeconfig <c1-kubeconfig> -o jsonpath='{.spec.value}'
+dr1
+```
+
+```console
+$ kubectl get clusterclaim name --kubeconfig <c2-kubeconfig> -o jsonpath='{.spec.value}'
+dr2
+```
+
+**If the ClusterClaim command fails**, stop and report the error to the
+user. {{.Command.Name}} uses the same mechanism to resolve cluster names, so it
+will not work without it. Common errors:
+
+- `error: the server doesn't have a resource type "clusterclaim"` — OCM
+  klusterlet is not installed on the cluster.
+- `Error from server (NotFound)` — OCM is installed but the `name`
+  claim hasn't been created yet.
+- Connection or authentication errors — the kubeconfig is wrong, expired,
+  or lacks permissions.
+
+#### 3b. List managed clusters and their clusterSets on the hub
+
+```console
+$ kubectl get managedclusters --kubeconfig <hub-kubeconfig> \
+  -L cluster.open-cluster-management.io/clusterset
+NAME            HUB ACCEPTED   MANAGED CLUSTER URLS                 JOINED   AVAILABLE   AGE   CLUSTERSET
+my-c1           true           https://api.my-c1.example.com:6443   True     True        16d   dr-clusters
+my-c2           true           https://api.my-c2.example.com:6443   True     True        16d   dr-clusters
+local-cluster   true           https://api.my-hub.example.com:6443  True     True        16d   default
+```
+
+#### 3c. Find the clusterSet that contains both clusters
+
+Match the OCM names from step 3a against the `NAME` column, and read the
+`CLUSTERSET` column.
+
+- If both clusters are in the same clusterSet, use that value.
+- If the clusters are in different clusterSets, something is
+  misconfigured. Ask the user to verify.
+- Ignore the `global` clusterSet (it automatically includes all clusters
+  and is not suitable for DR).
+
+With the default OCM `ExclusiveClusterSetLabel` selector type, a cluster
+belongs to exactly one clusterSet (set via the
+`cluster.open-cluster-management.io/clusterset` label). If there are
+multiple non-global clusterSets, present the options and let the user
+choose.
+
+#### 3d. Set the clusterSet in the config file
+
+```yaml
+clusterSet: dr-clusters
+```
+
+### Step 4: Configure test options (optional)
+
+Ask the user if they plan to run DR tests with `{{.Command.Name}} test run`. If
+they only need `validate` or `gather` commands, the configuration is
+complete — skip to step 5.
+
+> **Tip:** The defaults match the ramen testing environment. If using
+> one, no configuration is needed — skip to step 5.
+
+If the user wants to run tests, configure the following sections:
+
+#### 4a. drPolicy
+
+Ask the user which DRPolicy to use. List available policies on the hub:
+
+```console
+$ kubectl get drpolicies --kubeconfig <hub-kubeconfig> \
+    -o 'custom-columns=NAME:.metadata.name,INTERVAL:.spec.schedulingInterval,CLUSTERS:.spec.drClusters[*]'
+NAME             INTERVAL   CLUSTERS
+dr-policy-5m     5m         dr1,dr2
+```
+
+The name is typically `dr-policy-<interval>`, e.g., `dr-policy-5m`.
+Verify that the policy's DR clusters include both clusters from step 3a.
+If there are multiple policies, ask the user to choose one. Set the value
+in the config file:
+
+```yaml
+drPolicy: dr-policy-5m
+```
+
+#### 4b. pvcSpecs
+
+The storage class names must match the peer classes from the DRPolicy.
+Discover the available storage classes:
+
+```console
+$ kubectl get drpolicy <policy-name> --kubeconfig <hub-kubeconfig> \
+  -o 'jsonpath={range .status.async.peerClasses[*]}{.storageClassName}{"\n"}{end}'
+ocs-storagecluster-ceph-rbd
+ocs-storagecluster-ceph-rbd-virtualization
+ocs-storagecluster-cephfs
+```
+
+Example for OpenShift (ODF):
+
+```yaml
+pvcSpecs:
+- name: rbd
+  storageClassName: ocs-storagecluster-ceph-rbd
+  accessModes: ReadWriteOnce
+- name: rbd-virt
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  accessModes: ReadWriteOnce
+- name: cephfs
+  storageClassName: ocs-storagecluster-cephfs
+  accessModes: ReadWriteMany
+```
+
+#### 4c. tests
+
+Each test case is a combination of workload, deployer, and pvcSpec. The
+default runs one test:
+
+```yaml
+tests:
+- workload: deploy
+  deployer: appset
+  pvcSpec: rbd
+```
+
+This deploys a small application using the ApplicationSet deployer with
+RBD storage, then runs the full DR flow (failover + relocate).
+
+Available deployers: `appset`, `subscr`, `disapp`, `disapp-recipe`,
+`disapp-recipe-check`, `disapp-recipe-exec`, `disapp-recipe-check-exec`.
+
+To test more combinations, add entries using different deployers or
+pvcSpecs from 4b.
+
+### Step 5: Done
+
+There is no standalone config validation command yet. The configuration
+will be validated automatically when running any {{.Command.Name}} command
+(`validate clusters`, `validate application`, `test run`, etc.).
+
+## Reference
+
+- Default config file: `config.yaml` (used by all commands unless overridden
+  with `--config`)
+- Multiple config files can coexist for different environments or test sets
+- When using `--envfile`, the file is pre-populated but may still need
+  adjustments

--- a/pkg/skills/templates/skills/test-clean.tmpl
+++ b/pkg/skills/templates/skills/test-clean.tmpl
@@ -1,0 +1,59 @@
+{{- /* SPDX-FileCopyrightText: The RamenDR authors */ -}}
+{{- /* SPDX-License-Identifier: Apache-2.0 */ -}}
+---
+name: {{.Command.Slug}}-{{.Skill.Name}}
+description: >-
+  Clean up after {{.Command.Name}} test run using {{.Command.Name}} test clean.
+  Use when the user wants to clean up test resources, remove test artifacts,
+  or reset after a test run.
+---
+
+# {{.Command.Name}} test clean
+
+Delete resources created by `{{.Command.Name}} test run`.
+
+## Requirements
+
+- A previous `{{.Command.Name}} test run` was executed
+- `{{.Command.Name}} validate clusters` passes without problems. If
+  validation fails there is no point in cleaning tests.
+- If the test failed due to an infrastructure issue (e.g., rbd-mirror
+  down), **restore the infrastructure first** before cleaning. Cleaning
+  before restoring may fail or leave leftovers.
+
+## Workflow
+
+### Step 1: Run test clean
+
+Use the same output directory and config file as the test run:
+
+```console
+$ {{.Command.Name}} test clean -o <output-dir>
+```
+
+Use `--config <file>` if the config file is not the default `config.yaml`.
+
+The command unprotects and undeploys test applications, then cleans the
+test environment (channels, namespaces).
+
+### Step 2: Check the result
+
+**On success:**
+
+```console
+✅ passed (N passed, 0 failed, 0 skipped)
+```
+
+The output directory gains additional files after clean:
+
+| File | Purpose |
+|------|---------|
+| `test-clean.yaml` | Clean operation report |
+| `test-clean.log` | Detailed log |
+
+## Notes
+
+- Do not clean up without an explicit request from the user. Failed test
+  resources are evidence for debugging.
+- If clean fails, check the log for details. You may need to manually
+  delete stuck resources.

--- a/pkg/skills/templates/skills/test-run.tmpl
+++ b/pkg/skills/templates/skills/test-run.tmpl
@@ -1,0 +1,112 @@
+{{- /* SPDX-FileCopyrightText: The RamenDR authors */ -}}
+{{- /* SPDX-License-Identifier: Apache-2.0 */ -}}
+---
+name: {{.Command.Slug}}-{{.Skill.Name}}
+description: >-
+  Run disaster recovery tests using {{.Command.Name}} test run. Use when the
+  user wants to test DR flow, verify failover/relocate works, or run
+  end-to-end DR tests.
+---
+
+# {{.Command.Name}} test run
+
+Run a disaster recovery flow test with one or more tiny applications defined
+in the configuration file.
+
+## Requirements
+
+- A fully configured `config.yaml` including test options
+  (see {{.Command.Slug}}-init skill).
+- `{{.Command.Name}} validate clusters` passes without problems. If
+  validation fails there is no point in running tests.
+
+## Workflow
+
+### Step 1: Run the test
+
+Use `<env>/test` for the output directory, e.g., `myenv/test`.
+
+```console
+$ {{.Command.Name}} test run -o <output-dir>
+```
+
+Use `--config <file>` if the config file is not the default `config.yaml`.
+
+The test runs through the full DR flow for each test case:
+deploy, protect, failover, relocate, unprotect, undeploy.
+
+**This typically takes 15-20 minutes per test case.** Multiple test cases
+run in parallel.
+
+### Step 2: Check the result
+
+**On success:**
+
+```console
+✅ passed (N passed, 0 failed, 0 skipped)
+```
+
+**On failure** the command automatically gathers diagnostic data from all
+clusters and S3 into `test-run.data/`:
+
+```console
+❌ failed (N passed, M failed, 0 skipped)
+```
+
+### Step 3: Inspect the report
+
+The output directory contains:
+
+| File | Purpose |
+|------|---------|
+| `test-run.yaml` | Machine-readable test report |
+| `test-run.log` | Detailed log |
+| `test-run.data/` | Gathered data (only present on failure) |
+
+Useful commands:
+
+Overall status:
+
+```console
+$ yq '.status' < <output-dir>/test-run.yaml
+```
+
+Individual step status and durations:
+
+```console
+$ yq '.steps[-1].items' < <output-dir>/test-run.yaml
+```
+
+Test events from the log:
+
+```console
+$ grep -E '(INFO|ERROR).+<app-name>' <output-dir>/test-run.log
+```
+
+The `test-run.yaml` report contains the config used, each test step with
+its status and duration, and a summary with pass/fail/skip counts.
+
+### Step 4: Handle failures
+
+If the test failed:
+
+1. Check `test-run.yaml` to see which step failed
+2. Inspect `test-run.data/` for gathered resources and logs — it has the
+   same structure as validate-application gathered data (one directory per
+   cluster plus `s3/`)
+3. Check DRPC status, VRG conditions, and operator logs
+4. Fix the underlying issue
+5. **Always clean up** before re-running (see {{.Command.Slug}}-test-clean skill)
+
+### Step 5: Clean up
+
+Ask the user if they want to clean up. Do not clean up without an
+explicit request — failed test resources are evidence for debugging.
+See the {{.Command.Slug}}-test-clean skill for details.
+
+## Notes
+
+- Pressing Ctrl+C cancels gracefully. The current step may take up to
+  10 minutes to complete. Partial results are saved but data is not
+  gathered for incomplete tests.
+- To report DR issues, archive the entire output directory.

--- a/pkg/skills/templates/skills/validate-application.tmpl
+++ b/pkg/skills/templates/skills/validate-application.tmpl
@@ -1,0 +1,163 @@
+{{- /* SPDX-FileCopyrightText: The RamenDR authors */ -}}
+{{- /* SPDX-License-Identifier: Apache-2.0 */ -}}
+---
+name: {{.Command.Slug}}-{{.Skill.Name}}
+description: >-
+  Validate a DR-protected application using {{.Command.Name}} validate
+  application. Use when the user wants to check an application is ok,
+  check application DR health, troubleshoot a protected application, or
+  verify application status after failover/relocate. When triaging or
+  reporting bugs, also suggest {{.Command.Name}} validate clusters so the
+  user has both the app report and the cluster-wide DR report.
+---
+
+# {{.Command.Name}} validate application
+
+Validate a specific DR-protected application by gathering related namespaces
+from all clusters and S3 data, and inspecting the gathered resources.
+
+## Requirements
+
+- A configuration file with cluster kubeconfigs (see {{.Command.Slug}}-init skill)
+- At least one DR-protected application in the clusters
+
+## Workflow
+
+### Step 1: Look up protected applications
+
+List DRPCs on the hub using the hub kubeconfig from the {{.Command.Name}} config file:
+
+```console
+$ kubectl get drpc -A --kubeconfig <hub-kubeconfig>
+NAMESPACE          NAME       AGE   PREFERREDCLUSTER   FAILOVERCLUSTER   DESIREDSTATE   CURRENTSTATE
+openshift-dr-ops   app1       18d   c1                 c2                Failover       FailedOver
+openshift-gitops   app2       22d   c1                                                  Deployed
+```
+
+Present the list and let the user choose which application to validate.
+The `NAME` and `NAMESPACE` columns map to the `--name` and `--namespace`
+flags.
+
+### Step 2: Run validate application
+
+Use `<env>/<namespace>-<app-name>` for the output directory, e.g., `myenv/myns-myapp`.
+
+```console
+$ {{.Command.Name}} validate application --name <drpc-name> --namespace <namespace> -o <output-dir> --interactive=false
+```
+
+`--interactive=false` prevents {{.Command.Name}} from opening a browser—you open the
+report yourself in Step 4.
+
+Use `--config <file>` if the config file is not the default `config.yaml`.
+
+The command takes a few seconds on local clusters and about a minute on
+remote clusters.
+
+### Step 3: Check the result
+
+**On success:**
+
+```console
+✅ Validation completed (N ok, 0 warning, 0 problem)
+```
+
+**On problems** the command exits with a non-zero exit code:
+
+```console
+❌ Validation completed (N ok, M warning, P problem)
+```
+
+When validation **finishes and writes a report**, a non-zero exit always means
+there are problems **in** that report. If the command **fails before** a
+report is written (early error), there may be no HTML—use the log and console
+output instead.
+
+### Step 4: Open the HTML report
+
+If `<output-dir>/validate-application.html` exists, open it in the
+browser using `open <path>` (macOS), `xdg-open <path>` (Linux), or
+`cmd /c start "" <path>` (Windows). Do not skip unless the user asks
+to skip.
+
+The report may not exist if the command failed before writing it.
+
+### Step 5: Inspect the report
+
+The output directory contains:
+
+| File | Purpose |
+|------|---------|
+| `validate-application.yaml` | Machine and human readable report |
+| `validate-application.html` | HTML report |
+| `validate-application.log` | Detailed log |
+| `validate-application.data/` | Raw resources from all clusters + S3 |
+
+Read the application status:
+
+```console
+$ yq '.applicationStatus' < <output-dir>/validate-application.yaml
+```
+
+#### Gathered data structure
+
+```console
+$ tree -L3 <output-dir>/validate-application.data
+validate-application.data/
+├── <cluster>/
+│   ├── cluster/
+│   │   ├── namespaces/
+│   │   ├── persistentvolumes/
+│   │   └── storage.k8s.io/
+│   └── namespaces/
+│       └── <app-namespace>/
+├── ...
+└── s3/
+    └── <profile-name>/
+        └── <app-namespace>/
+```
+
+### Step 6: Troubleshoot problems
+
+This section is an **initial draft** — DR troubleshooting is hard and
+needs more playbooks over time (for example a future analyze skill).
+
+If problems were found, help the user understand them:
+
+1. Read the YAML report — look for `state:` values that are not `ok ✅`
+2. Check the log file for error details
+3. Inspect raw resources in `validate-application.data/`
+4. Summarize the findings and suggest what the user should look at
+
+Useful commands for inspecting gathered data:
+
+Check VRG status:
+
+```console
+$ yq '.status' < <output-dir>/validate-application.data/<cluster>/namespaces/<ns>/ramendr.openshift.io/volumereplicationgroups/<name>.yaml
+```
+
+Search ramen operator logs for errors related to the app:
+
+```console
+$ grep -E 'ERROR.+<app-name>' <output-dir>/validate-application.data/<cluster>/namespaces/ramen-system/pods/*/manager/current.log
+```
+
+### Step 7: Suggest validate clusters
+
+After completing the application validation, suggest also running
+`{{.Command.Name}} validate clusters` into a sibling output directory such as
+`<env>/clusters`. When they agree (or you run it for them), follow the
+**{{.Command.Slug}}-validate-clusters** skill end to end.
+
+Why this helps: the application report covers one DRPC, its namespaces, and
+S3 data (S3 reachability is already tested by the gather step). The cluster
+report adds hub and managed-cluster DR plumbing (operators, DRClusters,
+DRPolicies, ramen configmaps) that the application report does not cover.
+Having both makes it easier to see whether a problem is app-specific or
+infrastructure-wide. If the user already has a fresh cluster validation in
+the same environment, they can skip this.
+
+## Notes
+
+- To report DR issues, archive the entire output directory.

--- a/pkg/skills/templates/skills/validate-clusters.tmpl
+++ b/pkg/skills/templates/skills/validate-clusters.tmpl
@@ -1,0 +1,121 @@
+{{- /* SPDX-FileCopyrightText: The RamenDR authors */ -}}
+{{- /* SPDX-License-Identifier: Apache-2.0 */ -}}
+---
+name: {{.Command.Slug}}-{{.Skill.Name}}
+description: >-
+  Validate disaster recovery cluster configuration using
+  {{.Command.Name}} validate clusters. Use when the user wants to check
+  clusters are ok, verify DR setup, check cluster health, or troubleshoot
+  cluster-level DR problems.
+---
+
+# {{.Command.Name}} validate clusters
+
+Validate disaster recovery clusters by gathering cluster-scoped and ramen
+resources from all clusters, and checking that S3 endpoints are accessible.
+
+## Requirements
+
+- A configuration file with cluster kubeconfigs (see {{.Command.Slug}}-init skill)
+
+## Workflow
+
+### Step 1: Pick an output directory
+
+Ask the user where to store the report. Suggest `<env>/clusters` or
+`<env>-<date>/clusters`, e.g., `myenv/clusters`.
+
+### Step 2: Run validate clusters
+
+```console
+$ {{.Command.Name}} validate clusters -o <output-dir> --interactive=false
+```
+
+`--interactive=false` prevents {{.Command.Name}} from opening a browser—you open the
+report yourself in Step 4.
+
+Use `--config <file>` if the config file is not the default `config.yaml`.
+
+The command takes a few seconds on local clusters and about a minute on
+remote clusters.
+
+### Step 3: Check the result
+
+**On success** the last line shows:
+
+```console
+✅ Validation completed (N ok, 0 warning, 0 problem)
+```
+
+**On problems** the summary includes warning or problem counts and the
+command exits with a non-zero exit code:
+
+```console
+❌ Validation completed (N ok, M warning, P problem)
+```
+
+When validation **finishes and writes a report**, a non-zero exit always means
+there are problems **in** that report. If the command **fails before** a
+report is written (early error), there may be no HTML—use the log and console
+output instead.
+
+### Step 4: Open the HTML report
+
+If `<output-dir>/validate-clusters.html` exists, open it in the
+browser using `open <path>` (macOS), `xdg-open <path>` (Linux), or
+`cmd /c start "" <path>` (Windows). Do not skip unless the user asks
+to skip.
+
+The report may not exist if the command failed before writing it.
+
+### Step 5: Inspect the report
+
+The output directory contains:
+
+| File | Purpose |
+|------|---------|
+| `validate-clusters.yaml` | Machine and human readable report |
+| `validate-clusters.html` | HTML report |
+| `validate-clusters.log` | Detailed log for troubleshooting |
+| `validate-clusters.data/` | Raw resources gathered from all clusters |
+
+Read the YAML report to understand the status:
+
+```console
+$ yq '.clustersStatus' < <output-dir>/validate-clusters.yaml
+```
+
+#### Gathered data structure
+
+```console
+$ tree -L3 <output-dir>/validate-clusters.data
+validate-clusters.data/
+├── <cluster>/
+│   ├── cluster/
+│   │   ├── apiextensions.k8s.io/
+│   │   ├── namespaces/
+│   │   ├── nodes/
+│   │   ├── ramendr.openshift.io/
+│   │   ├── storage.k8s.io/
+│   │   └── ...
+│   └── namespaces/
+│       └── ramen-system/
+└── ...
+```
+
+### Step 6: Troubleshoot problems
+
+This section is an **initial draft** — DR troubleshooting is hard and
+needs more playbooks over time (for example a future analyze skill).
+
+If problems were found, help the user understand them:
+
+1. Read the YAML report — look for `state:` values that are not `ok ✅`
+2. Check the log file for error details
+3. Inspect raw resources in `validate-clusters.data/`
+4. Summarize the findings and suggest what the user should look at
+
+## Notes
+
+- To report DR issues, archive the entire output directory and upload it
+  to the issue tracker.

--- a/pkg/skills/templates/skills/validate-clusters.tmpl
+++ b/pkg/skills/templates/skills/validate-clusters.tmpl
@@ -16,7 +16,11 @@ resources from all clusters, and checking that S3 endpoints are accessible.
 
 ## Requirements
 
-- A configuration file with cluster kubeconfigs (see {{.Command.Slug}}-init skill)
+- A configuration file with cluster kubeconfigs.
+- If `config.yaml` already exists, do not run `{{.Command.Name}} init`; use the
+  existing config file.
+- If no config file exists, stop and ask the user to complete the
+  {{.Command.Slug}}-init workflow first.
 
 ## Workflow
 


### PR DESCRIPTION
Small follow-up to RamenDR/ramenctl#453 and RamenDR/ramenctl#455.

Bob confirmed the important part of the previous feedback: the validate-clusters skill should not point the agent back into init when `config.yaml` already exists.

This patch keeps the change narrow:

- clarifies that existing `config.yaml` should be reused;
- tells the agent to stop and ask for init only when no config exists;
- adds a focused regression assertion for the generated Bob validate-clusters skill.

Check run locally:

```console
go test ./pkg/skills
```