### PR TITLE
Guard long test runs by timeout support

### DIFF
--- a/pkg/skills/agent.go
+++ b/pkg/skills/agent.go
@@ -19,19 +19,21 @@ const (
 )
 
 type agent struct {
-	Name        string
-	DisplayName string
-	SkillsDir   string
-	ContextFile string
-	Hint        string
+	Name               string
+	DisplayName        string
+	SkillsDir          string
+	ContextFile        string
+	Hint               string
+	CanRunLongCommands bool
 }
 
 var agents = map[string]agent{
 	AgentCursor: {
-		Name:        AgentCursor,
-		DisplayName: "Cursor",
-		SkillsDir:   ".cursor/skills",
-		ContextFile: ".cursor/rules/ramenctl.mdc",
+		Name:               AgentCursor,
+		DisplayName:        "Cursor",
+		SkillsDir:          ".cursor/skills",
+		ContextFile:        ".cursor/rules/ramenctl.mdc",
+		CanRunLongCommands: true,
 	},
 	AgentClaude: {
 		Name:        AgentClaude,

--- a/pkg/skills/install.go
+++ b/pkg/skills/install.go
@@ -54,7 +54,7 @@ func installSkills(cmd Command, agent agent) bool {
 			}
 		}
 
-		content, err := renderSkill(skill, cmd)
+		content, err := renderSkill(skill, cmd, agent)
 		if err != nil {
 			console.Error("%s", err)
 			return false

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -44,9 +44,10 @@ var skills = []Skill{
 type skillData struct {
 	Command Command
 	Skill   Skill
+	Agent   agent
 }
 
-func renderSkill(skill Skill, cmd Command) ([]byte, error) {
+func renderSkill(skill Skill, cmd Command, ag agent) ([]byte, error) {
 	tmplPath := "templates/skills/" + skill.Name + ".tmpl"
 
 	content, err := skillsFS.ReadFile(tmplPath)
@@ -59,7 +60,7 @@ func renderSkill(skill Skill, cmd Command) ([]byte, error) {
 		return nil, fmt.Errorf("failed to parse skill template %q: %w", skill.Name, err)
 	}
 
-	data := skillData{Command: cmd, Skill: skill}
+	data := skillData{Command: cmd, Skill: skill, Agent: ag}
 
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, data); err != nil {

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -78,6 +78,19 @@ func TestInstallCommandName(t *testing.T) {
 	assertContextContains(t, ".cursor/skills/odf-dr-init/SKILL.md", "odf dr")
 }
 
+func TestTestRunSkillDefinesLongCommandBoundary(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if !skills.Install("ramenctl", skills.AgentBob) {
+		t.Fatal("install failed")
+	}
+
+	path := ".bob/skills/ramenctl-test-run/SKILL.md"
+	assertContextContains(t, path, "at least 25 minutes")
+	assertContextContains(t, path, "If the current harness cannot set a long enough timeout, do not start")
+	assertContextContains(t, path, "do not retry, restart, or kill the command")
+}
+
 // Multiple agents. Users may run init with different agents in the same
 // directory. Verify that all agents validate regardless of install order.
 

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -79,16 +79,44 @@ func TestInstallCommandName(t *testing.T) {
 }
 
 func TestTestRunSkillDefinesLongCommandBoundary(t *testing.T) {
-	t.Chdir(t.TempDir())
+	for _, tt := range []struct {
+		name          string
+		agent         string
+		skillsDir     string
+		expectRun     string
+		expectHandoff string
+	}{
+		{
+			name:      "cursor runs long command directly",
+			agent:     skills.AgentCursor,
+			skillsDir: ".cursor/skills",
+			expectRun: "Start the command only when",
+		},
+		{
+			name:          "bob hands long command to shell",
+			agent:         skills.AgentBob,
+			skillsDir:     ".bob/skills",
+			expectHandoff: "Do not start `ramenctl test run` from this agent unless its",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
 
-	if !skills.Install("ramenctl", skills.AgentBob) {
-		t.Fatal("install failed")
+			if !skills.Install("ramenctl", tt.agent) {
+				t.Fatal("install failed")
+			}
+
+			path := filepath.Join(tt.skillsDir, "ramenctl-test-run", "SKILL.md")
+			assertContextContains(t, path, "at least 25")
+			assertContextContains(t, path, "do not retry")
+			if tt.expectRun != "" {
+				assertContextContains(t, path, tt.expectRun)
+			}
+			if tt.expectHandoff != "" {
+				assertContextContains(t, path, tt.expectHandoff)
+			}
+		})
 	}
-
-	path := ".bob/skills/ramenctl-test-run/SKILL.md"
-	assertContextContains(t, path, "at least 25 minutes")
-	assertContextContains(t, path, "If the current harness cannot set a long enough timeout, do not start")
-	assertContextContains(t, path, "do not retry, restart, or kill the command")
 }
 
 // Multiple agents. Users may run init with different agents in the same

--- a/pkg/skills/templates/skills/test-clean.tmpl
+++ b/pkg/skills/templates/skills/test-clean.tmpl
@@ -32,13 +32,32 @@ inspect.
 Use the same output directory and config file as the test run, e.g.,
 `out/test`:
 
+{{- if .Agent.CanRunLongCommands }}
 ```console
 $ {{.Command.Name}} test clean -o out/test
 ```
 
 The command unprotects and undeploys test applications, then cleans the
 test environment (channels, namespaces). **This typically takes up to 5
-minutes.**
+minutes.** If the command fails or times out, report to the user and wait
+for instructions — do not retry, restart, or kill the command.
+{{- else }}
+Do not start `{{.Command.Name}} test clean` from this agent unless its
+harness is known to support cleanup commands that may run for several
+minutes without force-stopping them.
+
+Ask the user to run the command in a shell or another agent with suitable
+long-command support:
+
+```console
+$ {{.Command.Name}} test clean -o out/test
+```
+
+After the command finishes, continue from the generated clean report. If
+the user reports that clean failed or timed out, inspect the saved
+report/logs and wait for instructions — do not retry, restart, or kill the
+command.
+{{- end }}
 
 ### Step 2: Check the result
 

--- a/pkg/skills/templates/skills/test-run.tmpl
+++ b/pkg/skills/templates/skills/test-run.tmpl
@@ -29,13 +29,18 @@ Ask the user where to store the report. Suggest `out/test`. If the
 directory already exists, suggest a new name like `out/test-2`,
 `out/test-3`, etc.
 
+**This typically takes 15-20 minutes** regardless of the number of test
+cases, since all test cases run in parallel. Before starting, confirm the
+current agent or terminal can let one command run for at least 25 minutes.
+If the current harness cannot set a long enough timeout, do not start the
+command. Ask the user to run it in an external terminal or an agent that
+supports long-running commands, then continue from the generated report.
+
 ```console
 $ {{.Command.Name}} test run -o <output-dir>
 ```
 
-**This typically takes 15-20 minutes** regardless of the number of test
-cases, since all test cases run in parallel. Show the command output in
-the chat so the user can follow the progress.
+Show the command output in the chat so the user can follow the progress.
 
 If the command fails or times out, report to the user and wait for
 instructions — do not retry, restart, or kill the command.

--- a/pkg/skills/templates/skills/test-run.tmpl
+++ b/pkg/skills/templates/skills/test-run.tmpl
@@ -29,12 +29,10 @@ Ask the user where to store the report. Suggest `out/test`. If the
 directory already exists, suggest a new name like `out/test-2`,
 `out/test-3`, etc.
 
+{{- if .Agent.CanRunLongCommands }}
 **This typically takes 15-20 minutes** regardless of the number of test
-cases, since all test cases run in parallel. Before starting, confirm the
-current agent or terminal can let one command run for at least 25 minutes.
-If the current harness cannot set a long enough timeout, do not start the
-command. Ask the user to run it in an external terminal or an agent that
-supports long-running commands, then continue from the generated report.
+cases, since all test cases run in parallel. Start the command only when
+the current agent/terminal can let one command run for at least 25 minutes.
 
 ```console
 $ {{.Command.Name}} test run -o <output-dir>
@@ -44,6 +42,27 @@ Show the command output in the chat so the user can follow the progress.
 
 If the command fails or times out, report to the user and wait for
 instructions — do not retry, restart, or kill the command.
+{{- else }}
+**This typically takes 15-20 minutes** regardless of the number of test
+cases, since all test cases run in parallel.
+
+Do not start `{{.Command.Name}} test run` from this agent unless its
+harness is known to support a single command running for at least 25
+minutes. Some agents may claim they started the command with a long
+timeout while the harness still force-stops it earlier.
+
+Ask the user to run the command in a shell or another agent that supports
+long-running commands:
+
+```console
+$ {{.Command.Name}} test run -o <output-dir>
+```
+
+After the command finishes, continue from the generated report in
+`<output-dir>`. If the user reports that the command failed or timed out,
+inspect the saved report/logs and wait for instructions — do not retry,
+restart, or kill the command.
+{{- end }}
 
 ### Step 2: Check the result
 


### PR DESCRIPTION
This follows the Bob test-run finding from RamenDR/ramenctl#453: the skill can be discovered correctly, but `ramenctl test run` is a long-running command and some harnesses may hard-timeout before completion.

Change:
- before starting `ramenctl test run`, require an agent/terminal that can let one command run for at least 25 minutes;
- if the current harness cannot set a long enough timeout, do not start the command; ask the user to run it in an external terminal or long-command-capable agent and continue from the generated report;
- keep the existing “do not retry/restart/kill” boundary;
- add a regression assertion for the generated Bob test-run skill.

Local check:

```console
go test ./pkg/skills
```

Scope: only the test-run long-command boundary. I left the existing skill discovery/config handoff wording untouched.